### PR TITLE
Autocopy by result button

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -87,7 +87,7 @@ void Settings::load()
                                           true ).toBool();
     systemTrayIconVisible = settings->value( key + QLatin1String("SystemTrayIconVisible"),
                                              false ).toBool();
-    autoCopyResultToCb = settings->value( key + QLatin1String("AutoCopyResultToCb"), false ).toBool();
+    autoResultToClipboard = settings->value( key + QLatin1String("AutoResultToClipboard"), false ).toBool();
 
     key = KEY + QLatin1String("/Format/");
 
@@ -209,7 +209,7 @@ void Settings::save()
     settings->setValue( key + QLatin1String("AutoCalc"), autoCalc );
     settings->setValue( key + QLatin1String("SystemTrayIconVisible"), systemTrayIconVisible );
     settings->setValue( key + QLatin1String("SyntaxHighlighting"), syntaxHighlighting );
-    settings->setValue( key + QLatin1String("AutoCopyResultToCb"), autoCopyResultToCb );
+    settings->setValue( key + QLatin1String("AutoResultToClipboard"), autoResultToClipboard );
     settings->setValue( key + QLatin1String("Language"), language );
 
     settings->setValue( key + QLatin1String("AngleMode"), QString(QChar(angleUnit)) );

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -50,7 +50,7 @@ public:
     bool systemTrayIconVisible;
     bool variableSave;
     bool windowAlwaysOnTop;
-    bool autoCopyResultToCb;
+    bool autoResultToClipboard;
 
     bool constantsDockVisible;
     bool functionsDockVisible;
@@ -61,7 +61,6 @@ public:
     bool statusBarVisible;
     bool variablesDockVisible;
     bool windowOnfullScreen;
-    
 
     QString displayFont;
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -137,8 +137,7 @@ struct Actions
     QAction * settingsBehaviorAutoAns;
     QAction * settingsBehaviorAlwaysOnTop;
     QAction * settingsBehaviorMinimizeToTray;
-    QAction * settingsBehaviorAutoCopyResultToCb;
-
+    QAction * settingsBehaviorAutoResultToClipboard;
     // settings / display
     QAction * settingsDisplayZoomIn;
     QAction * settingsDisplayZoomOut;
@@ -392,15 +391,15 @@ void MainWindow::Private::createActions()
     actions.settingsAngleUnitDegree = new QAction( p );
     actions.settingsAngleUnitRadian = new QAction( p );
 
-    actions.settingsBehaviorAlwaysOnTop         = new QAction( p );
-    actions.settingsBehaviorAutoAns             = new QAction( p );
-    actions.settingsBehaviorAutoCompletion      = new QAction( p );
-    actions.settingsBehaviorMinimizeToTray      = new QAction( p );
-    actions.settingsBehaviorPartialResults      = new QAction( p );
-    actions.settingsBehaviorSaveHistoryOnExit   = new QAction( p );
-    actions.settingsBehaviorSaveVariablesOnExit = new QAction( p );
-    actions.settingsBehaviorSyntaxHilite        = new QAction( p );
-    actions.settingsBehaviorAutoCopyResultToCb  = new QAction( p );
+    actions.settingsBehaviorAlwaysOnTop           = new QAction( p );
+    actions.settingsBehaviorAutoAns               = new QAction( p );
+    actions.settingsBehaviorAutoCompletion        = new QAction( p );
+    actions.settingsBehaviorMinimizeToTray        = new QAction( p );
+    actions.settingsBehaviorPartialResults        = new QAction( p );
+    actions.settingsBehaviorSaveHistoryOnExit     = new QAction( p );
+    actions.settingsBehaviorSaveVariablesOnExit   = new QAction( p );
+    actions.settingsBehaviorSyntaxHilite          = new QAction( p );
+    actions.settingsBehaviorAutoResultToClipboard = new QAction( p );
 
     actions.settingsDisplayZoomIn  = new QAction( p );
     actions.settingsDisplayZoomOut = new QAction( p );
@@ -437,15 +436,15 @@ void MainWindow::Private::createActions()
     actions.settingsAngleUnitDegree->setCheckable( true );
     actions.settingsAngleUnitRadian->setCheckable( true );
 
-    actions.settingsBehaviorAlwaysOnTop        ->setCheckable( true );
-    actions.settingsBehaviorAutoAns            ->setCheckable( true );
-    actions.settingsBehaviorAutoCompletion     ->setCheckable( true );
-    actions.settingsBehaviorMinimizeToTray     ->setCheckable( true );
-    actions.settingsBehaviorPartialResults     ->setCheckable( true );
-    actions.settingsBehaviorSaveHistoryOnExit  ->setCheckable( true );
-    actions.settingsBehaviorSaveVariablesOnExit->setCheckable( true );
-    actions.settingsBehaviorSyntaxHilite       ->setCheckable( true );
-    actions.settingsBehaviorAutoCopyResultToCb ->setCheckable( true );
+    actions.settingsBehaviorAlwaysOnTop          ->setCheckable( true );
+    actions.settingsBehaviorAutoAns              ->setCheckable( true );
+    actions.settingsBehaviorAutoCompletion       ->setCheckable( true );
+    actions.settingsBehaviorMinimizeToTray       ->setCheckable( true );
+    actions.settingsBehaviorPartialResults       ->setCheckable( true );
+    actions.settingsBehaviorSaveHistoryOnExit    ->setCheckable( true );
+    actions.settingsBehaviorSaveVariablesOnExit  ->setCheckable( true );
+    actions.settingsBehaviorSyntaxHilite         ->setCheckable( true );
+    actions.settingsBehaviorAutoResultToClipboard->setCheckable( true );
 
     actions.settingsRadixCharComma  ->setCheckable( true );
     actions.settingsRadixCharDefault->setCheckable( true );
@@ -556,37 +555,37 @@ void MainWindow::Private::setActionsText()
     actions.viewStatusBar     ->setText( MainWindow::tr("&Status Bar") );
     actions.viewVariables     ->setText( MainWindow::tr("&Variables") );
 
-    actions.settingsAngleUnitDegree            ->setText( MainWindow::tr("&Degree") );
-    actions.settingsAngleUnitRadian            ->setText( MainWindow::tr("&Radian") );
-    actions.settingsBehaviorAlwaysOnTop        ->setText( MainWindow::tr("Always On &Top") );
-    actions.settingsBehaviorAutoAns            ->setText( MainWindow::tr("Automatic Result &Reuse") );
-    actions.settingsBehaviorAutoCompletion     ->setText( MainWindow::tr("Automatic &Completion") );
-    actions.settingsBehaviorMinimizeToTray     ->setText( MainWindow::tr("&Minimize To System Tray") );
-    actions.settingsBehaviorPartialResults     ->setText( MainWindow::tr("&Partial Results") );
-    actions.settingsBehaviorSaveHistoryOnExit  ->setText( MainWindow::tr("Save &History on Exit") );
-    actions.settingsBehaviorSaveVariablesOnExit->setText( MainWindow::tr("Save &Variables on Exit") );
-    actions.settingsBehaviorSyntaxHilite       ->setText( MainWindow::tr("Syntax &Highlighting") );
-    actions.settingsBehaviorAutoCopyResultToCb ->setText( MainWindow::tr("&Auto Copy Result To Clipboard") );
-    actions.settingsRadixCharComma             ->setText( MainWindow::tr("&Comma") );
-    actions.settingsRadixCharDefault           ->setText( MainWindow::tr("&System Default") );
-    actions.settingsRadixCharDot               ->setText( MainWindow::tr("&Dot") );
-    actions.settingsResultFormat15Digits       ->setText( MainWindow::tr("&15 Decimal Digits") );
-    actions.settingsResultFormat2Digits        ->setText( MainWindow::tr("&2 Decimal Digits") );
-    actions.settingsResultFormat3Digits        ->setText( MainWindow::tr("&3 Decimal Digits") );
-    actions.settingsResultFormat50Digits       ->setText( MainWindow::tr("&50 Decimal Digits") );
-    actions.settingsResultFormat8Digits        ->setText( MainWindow::tr("&8 Decimal Digits") );
-    actions.settingsResultFormatAutoPrecision  ->setText( MainWindow::tr("&Automatic") );
-    actions.settingsResultFormatBinary         ->setText( MainWindow::tr("&Binary") );
-    actions.settingsResultFormatEngineering    ->setText( MainWindow::tr("&Engineering") );
-    actions.settingsResultFormatFixed          ->setText( MainWindow::tr("&Fixed Decimal") );
-    actions.settingsResultFormatGeneral        ->setText( MainWindow::tr("&General") );
-    actions.settingsResultFormatHexadecimal    ->setText( MainWindow::tr("&Hexadecimal") );
-    actions.settingsResultFormatOctal          ->setText( MainWindow::tr("&Octal") );
-    actions.settingsResultFormatScientific     ->setText( MainWindow::tr("&Scientific") );
-    actions.settingsDisplayZoomIn              ->setText( MainWindow::tr("Zoom &In") );
-    actions.settingsDisplayZoomOut             ->setText( MainWindow::tr("Zoom &Out") );
-    actions.settingsDisplayFont                ->setText( MainWindow::tr("&Font...") );
-    actions.settingsLanguage                   ->setText( MainWindow::tr("&Language...") );
+    actions.settingsAngleUnitDegree              ->setText( MainWindow::tr("&Degree") );
+    actions.settingsAngleUnitRadian              ->setText( MainWindow::tr("&Radian") );
+    actions.settingsBehaviorAlwaysOnTop          ->setText( MainWindow::tr("Always On &Top") );
+    actions.settingsBehaviorAutoAns              ->setText( MainWindow::tr("Automatic Result &Reuse") );
+    actions.settingsBehaviorAutoCompletion       ->setText( MainWindow::tr("Automatic &Completion") );
+    actions.settingsBehaviorMinimizeToTray       ->setText( MainWindow::tr("&Minimize To System Tray") );
+    actions.settingsBehaviorPartialResults       ->setText( MainWindow::tr("&Partial Results") );
+    actions.settingsBehaviorSaveHistoryOnExit    ->setText( MainWindow::tr("Save &History on Exit") );
+    actions.settingsBehaviorSaveVariablesOnExit  ->setText( MainWindow::tr("Save &Variables on Exit") );
+    actions.settingsBehaviorSyntaxHilite         ->setText( MainWindow::tr("Syntax &Highlighting") );
+    actions.settingsBehaviorAutoResultToClipboard->setText( MainWindow::tr("Automatic &Result to Clipboard") );
+    actions.settingsRadixCharComma               ->setText( MainWindow::tr("&Comma") );
+    actions.settingsRadixCharDefault             ->setText( MainWindow::tr("&System Default") );
+    actions.settingsRadixCharDot                 ->setText( MainWindow::tr("&Dot") );
+    actions.settingsResultFormat15Digits         ->setText( MainWindow::tr("&15 Decimal Digits") );
+    actions.settingsResultFormat2Digits          ->setText( MainWindow::tr("&2 Decimal Digits") );
+    actions.settingsResultFormat3Digits          ->setText( MainWindow::tr("&3 Decimal Digits") );
+    actions.settingsResultFormat50Digits         ->setText( MainWindow::tr("&50 Decimal Digits") );
+    actions.settingsResultFormat8Digits          ->setText( MainWindow::tr("&8 Decimal Digits") );
+    actions.settingsResultFormatAutoPrecision    ->setText( MainWindow::tr("&Automatic") );
+    actions.settingsResultFormatBinary           ->setText( MainWindow::tr("&Binary") );
+    actions.settingsResultFormatEngineering      ->setText( MainWindow::tr("&Engineering") );
+    actions.settingsResultFormatFixed            ->setText( MainWindow::tr("&Fixed Decimal") );
+    actions.settingsResultFormatGeneral          ->setText( MainWindow::tr("&General") );
+    actions.settingsResultFormatHexadecimal      ->setText( MainWindow::tr("&Hexadecimal") );
+    actions.settingsResultFormatOctal            ->setText( MainWindow::tr("&Octal") );
+    actions.settingsResultFormatScientific       ->setText( MainWindow::tr("&Scientific") );
+    actions.settingsDisplayZoomIn                ->setText( MainWindow::tr("Zoom &In") );
+    actions.settingsDisplayZoomOut               ->setText( MainWindow::tr("Zoom &Out") );
+    actions.settingsDisplayFont                  ->setText( MainWindow::tr("&Font...") );
+    actions.settingsLanguage                     ->setText( MainWindow::tr("&Language...") );
 
     actions.helpAboutQt    ->setText( MainWindow::tr("About &Qt") );
     actions.helpAbout      ->setText( MainWindow::tr("About &SpeedCrunch") );
@@ -768,7 +767,7 @@ void MainWindow::Private::createMenus()
     menus.behavior->addSeparator();
     menus.behavior->addAction( actions.settingsBehaviorAlwaysOnTop );
     menus.behavior->addAction( actions.settingsBehaviorMinimizeToTray );
-    menus.behavior->addAction( actions.settingsBehaviorAutoCopyResultToCb );
+    menus.behavior->addAction( actions.settingsBehaviorAutoResultToClipboard );
 
     menus.display = menus.settings->addMenu( "" );
     menus.display->addAction( actions.settingsDisplayZoomIn );
@@ -1109,9 +1108,8 @@ void MainWindow::Private::createFixedConnections()
              SLOT(setVariableSaveEnabled(bool)) );
     connect( actions.settingsBehaviorSyntaxHilite, SIGNAL(toggled(bool)), p,
              SLOT(setSyntaxHighlightingEnabled(bool)) );
-    connect( actions.settingsBehaviorAutoCopyResultToCb, SIGNAL(toggled(bool)), p,
-             SLOT(setAutoCopyResultToCbEnabled(bool)) );
-
+    connect( actions.settingsBehaviorAutoResultToClipboard, SIGNAL(toggled(bool)), p,
+             SLOT(setAutoResultToClipboardEnabled(bool)) );
 
     connect( actions.settingsRadixCharComma, SIGNAL(triggered()), p,
              SLOT(setRadixCharacterComma()) );
@@ -1263,11 +1261,10 @@ void MainWindow::Private::applySettings()
         p->setSyntaxHighlightingEnabled( false );
 
     // auto copy result to clipboard
-
-    if ( settings->autoCopyResultToCb )
-        actions.settingsBehaviorAutoCopyResultToCb->setChecked( true );
+    if ( settings->autoResultToClipboard )
+        actions.settingsBehaviorAutoResultToClipboard->setChecked( true );
     else
-        p->setAutoCopyResultToCbEnabled( false );
+        p->setAutoResultToClipboardEnabled( false );
 
     // display font
     QFont f;
@@ -1766,9 +1763,9 @@ void MainWindow::setSyntaxHighlightingEnabled( bool b )
     d->widgets.display->highlight();
 }
 
-void MainWindow::setAutoCopyResultToCbEnabled( bool b )
+void MainWindow::setAutoResultToClipboardEnabled( bool b )
 {
-    d->settings->autoCopyResultToCb = b;
+    d->settings->autoResultToClipboard = b;
 }
 
 void MainWindow::setAngleModeRadian()
@@ -2444,7 +2441,7 @@ void MainWindow::evaluateEditorExpression()
             HistoryWidget * history = qobject_cast<HistoryWidget *>( d->docks.history->widget() );
             history->append( str );
         }
-        if ( d->settings->autoCopyResultToCb )
+        if ( d->settings->autoResultToClipboard )
             copyResultToClipboard();
 
         d->widgets.editor->selectAll();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -105,7 +105,7 @@ private slots:
     void setResultPrecision( int );
     void setStatusBarVisible( bool );
     void setSyntaxHighlightingEnabled( bool );
-    void setAutoCopyResultToCbEnabled( bool );
+    void setAutoResultToClipboardEnabled( bool );
     void setSystemTrayIconEnabled( bool );
     void setVariableSaveEnabled( bool );
     void setVariablesDockVisible( bool );


### PR DESCRIPTION
Hi, 
Could you please review my patch for auto coping to clipboard without any hot-keys?
This is implemented as option in "Settings->Behavior->Auto Copy Result to Clipboard".
When option is enabled, result of operation is copied to clipboard automatically. 
