### PR TITLE
fix for Automatic Result Reuse not working with - operator

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2109,7 +2109,7 @@ void MainWindow::handleEditorTextChange()
         if (expr.isEmpty())
             return;
 
-        Tokens tokens = m_evaluator->scan(expr);
+        Tokens tokens = m_evaluator->scan(expr, Evaluator::NoAutoFix);
         if (tokens.count() == 1) {
             bool operatorCondition =
                 tokens.at(0).asOperator() == Token::Plus


### PR DESCRIPTION
Automatic Result Reuse does not work with the - operator because of AutoFix prepending a 0. Setting Evaluator::NoAutoFix for the token scan solves this problem.
