### PR TITLE
Build & run with Qt4 and Qt5

### DIFF
--- a/src/core/constants.cpp
+++ b/src/core/constants.cpp
@@ -23,7 +23,7 @@
 #include "core/numberformatter.h"
 #include "math/hmath.h"
 
-#include <QtCore/QCoreApplication>
+#include <QCoreApplication>
 
 #include <algorithm>
 

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -21,7 +21,7 @@
 #ifndef CORE_CONSTANTS_H
 #define CORE_CONSTANTS_H
 
-#include <QtCore/QStringList>
+#include <QStringList>
 
 #include <memory>
 

--- a/src/core/evaluator.cpp
+++ b/src/core/evaluator.cpp
@@ -21,13 +21,13 @@
 
 #include "core/evaluator.h"
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QStack>
+#include <QCoreApplication>
+#include <QStack>
 
 //#define EVALUATOR_DEBUG
 #ifdef EVALUATOR_DEBUG
-#include <QtCore/QFile>
-#include <QtCore/QTextStream>
+#include <QFile>
+#include <QTextStream>
 
 QTextStream& operator<<(QTextStream& s, HNumber num)
 {

--- a/src/core/evaluator.h
+++ b/src/core/evaluator.h
@@ -23,12 +23,12 @@
 #include "core/functions.h"
 #include "math/hmath.h"
 
-#include <QtCore/QHash>
-#include <QtCore/QObject>
-#include <QtCore/QSet>
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QVector>
+#include <QHash>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+#include <QVector>
 
 class Token {
 public:

--- a/src/core/functions.cpp
+++ b/src/core/functions.cpp
@@ -25,8 +25,8 @@
 #include "core/settings.h"
 #include "math/hmath.h"
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QHash>
+#include <QCoreApplication>
+#include <QHash>
 
 #include <algorithm>
 #include <functional>

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -23,9 +23,9 @@
 #include "core/errors.h"
 #include "math/hmath.h"
 
-#include <QtCore/QHash>
-#include <QtCore/QStringList>
-#include <QtCore/QVector>
+#include <QHash>
+#include <QStringList>
+#include <QVector>
 
 class Function;
 

--- a/src/core/pageserver.h
+++ b/src/core/pageserver.h
@@ -19,8 +19,9 @@
 #ifndef CORE_PAGESERVER_H
 #define CORE_PAGESERVER_H
 
-#include <QtCore/QHash>
-#include <QtCore/QString>
+#include <QHash>
+#include <QObject>
+#include <QString>
 
 class PageServer : public QObject {
 public:

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -23,11 +23,11 @@
 #include "thirdparty/binreloc.h"
 #include "math/floatconfig.h"
 
-#include <QtCore/QDir>
-#include <QtCore/QLocale>
-#include <QtCore/QSettings>
-#include <QtGui/QApplication>
-#include <QtGui/QFont>
+#include <QDir>
+#include <QLocale>
+#include <QSettings>
+#include <QApplication>
+#include <QFont>
 
 static Settings* s_settingsInstance = 0;
 static char s_radixCharacter = 0;
@@ -70,12 +70,12 @@ void Settings::load()
     if (angleUnitStr != QLatin1String("r") && angleUnitStr != QLatin1String("d"))
         angleUnit = 'r';
     else
-        angleUnit = angleUnitStr.at(0).toAscii();
+        angleUnit = angleUnitStr.at(0).toLatin1();
 
     // Radix character special case.
     QString radixCharStr;
     radixCharStr = settings->value(key + QLatin1String("RadixCharacter"), 0).toString();
-    setRadixCharacter(radixCharStr.at(0).toAscii());
+    setRadixCharacter(radixCharStr.at(0).toLatin1());
 
     autoAns = settings->value(key + QLatin1String("AutoAns"), true).toBool();
     autoCalc = settings->value(key + QLatin1String("AutoCalc"), true).toBool();
@@ -97,7 +97,7 @@ void Settings::load()
     if (format != "g" && format != "f" && format != "e" && format != "n"&& format != "h" && format != "o" && format != "b")
         resultFormat = 'f';
     else
-        resultFormat = format.at(0).toAscii();
+        resultFormat = format.at(0).toLatin1();
 
     resultPrecision = settings->value(key + QLatin1String("Precision"), -1).toInt();
 
@@ -301,7 +301,7 @@ void Settings::save()
 
 char Settings::radixCharacter() const
 {
-    return s_radixCharacter == 0 ? QLocale().decimalPoint().toAscii() : s_radixCharacter;
+    return s_radixCharacter == 0 ? QLocale().decimalPoint().toLatin1() : s_radixCharacter;
 }
 
 bool Settings::isRadixCharacterAuto() const
@@ -318,8 +318,8 @@ QSettings* createQSettings(const QString& KEY)
 {
     QSettings* settings = 0;
 
-#ifdef Q_WS_WIN
 #ifdef SPEEDCRUNCH_PORTABLE
+#if defined(Q_WS_WIN)
     // Portable Windows version: settings are from INI file in same directory.
     QString appPath = QApplication::applicationFilePath();
     int ii = appPath.lastIndexOf('/');
@@ -327,20 +327,7 @@ QSettings* createQSettings(const QString& KEY)
         appPath.remove(ii, appPath.length());
     QString iniFile = appPath + '/' + KEY + ".ini";
     settings = new QSettings(iniFile, QSettings::IniFormat);
-#else
-    // Regular Windows version, settings are from the registry HKEY_CURRENT_USER\Software\SpeedCrunch.
-    settings = new QSettings(QSettings::NativeFormat, QSettings::UserScope, KEY, KEY);
-#endif // SPEEDCRUNCH_PORTABLE
-#endif // Q_WS_WIN
-
-
-#ifdef Q_WS_MAC
-    settings = new QSettings(QSettings::NativeFormat, QSettings::UserScope, KEY, KEY);
-#endif // Q_WS_MAC
-
-
-#if defined (Q_WS_X11) || defined (Q_WS_QWS)
-#ifdef SPEEDCRUNCH_PORTABLE
+#elif defined(Q_WS_X11) || defined (Q_WS_QWS)
     // Portable X11 version: settings are from INI file in the same directory.
     BrInitError error;
     if (br_init(& error) == 0 && error != BR_INIT_ERROR_DISABLED) {
@@ -352,11 +339,10 @@ QSettings* createQSettings(const QString& KEY)
     QString iniFile = QString(prefix) + '/' + KEY + QLatin1String(".ini");
     free(prefix);
     settings = new QSettings(iniFile, QSettings::IniFormat);
-#else
-    // Regular Unix or Embedded Linux (not Mac) version: settings from $HOME/.config/SpeedCrunch.
+#endif // Q_WS_WIN / Q_WS_X11 || Q_WS_QWS
+#else // SPEEDCRUNCH_PORTABLE
     settings = new QSettings(QSettings::NativeFormat, QSettings::UserScope, KEY, KEY);
 #endif // SPEEDCRUNCH_PORTABLE
-#endif // Q_WS_X11 || Q_WS_QWS
 
     return settings;
 }

--- a/src/gui/aboutbox.cpp
+++ b/src/gui/aboutbox.cpp
@@ -20,12 +20,12 @@
 
 #include "gui/aboutbox.h"
 
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QPushButton>
-#include <QtGui/QSpacerItem>
-#include <QtGui/QTextEdit>
-#include <QtGui/QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpacerItem>
+#include <QTextEdit>
+#include <QVBoxLayout>
 
 AboutBox::AboutBox(QWidget* parent, Qt::WindowFlags f)
     : QDialog(parent, f)

--- a/src/gui/aboutbox.h
+++ b/src/gui/aboutbox.h
@@ -20,7 +20,7 @@
 #ifndef GUI_ABOUTBOX_H
 #define GUI_ABOUTBOX_H
 
-#include <QtGui/QDialog>
+#include <QDialog>
 
 class AboutBox : public QDialog {
     Q_OBJECT

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -20,11 +20,11 @@
 
 #include "gui/application.h"
 
-#include <QtCore/QByteArray>
+#include <QByteArray>
 
-#include <QtCore/QSharedMemory>
-#include <QtNetwork/QLocalServer>
-#include <QtNetwork/QLocalSocket>
+#include <QSharedMemory>
+#include <QLocalServer>
+#include <QLocalSocket>
 
 #define GUI_APPLICATION_SHARED_MEMORY_KEY "speedcrunch"
 #define GUI_APPLICATION_LOCAL_SOCKET_TIMEOUT 1000

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -21,8 +21,8 @@
 #ifndef GUI_APPLICATION_H
 #define GUI_APPLICATION_H
 
-#include <QtCore/QScopedPointer>
-#include <QtGui/QApplication>
+#include <QScopedPointer>
+#include <QApplication>
 
 class ApplicationPrivate;
 

--- a/src/gui/bookdock.cpp
+++ b/src/gui/bookdock.cpp
@@ -22,9 +22,9 @@
 #include "core/book.h"
 #include "core/settings.h"
 
-#include <QtCore/QEvent>
-#include <QtGui/QTextBrowser>
-#include <QtGui/QVBoxLayout>
+#include <QEvent>
+#include <QTextBrowser>
+#include <QVBoxLayout>
 
 BookDock::BookDock(QWidget* parent)
     : QDockWidget(parent)

--- a/src/gui/bookdock.h
+++ b/src/gui/bookdock.h
@@ -22,8 +22,8 @@
 
 #include "core/book.h"
 
-#include <QtGui/QDockWidget>
-#include <QtGui/QTextBrowser>
+#include <QDockWidget>
+#include <QTextBrowser>
 
 class QUrl;
 

--- a/src/gui/constantsdock.cpp
+++ b/src/gui/constantsdock.cpp
@@ -21,7 +21,7 @@
 
 #include "gui/constantswidget.h"
 
-#include <QtCore/QEvent>
+#include <QEvent>
 
 ConstantsDock::ConstantsDock(QWidget *parent)
     : QDockWidget(parent)

--- a/src/gui/constantsdock.h
+++ b/src/gui/constantsdock.h
@@ -20,7 +20,7 @@
 #ifndef GUI_CONSTANTSDOCK_H
 #define GUI_CONSTANTSDOCK_H
 
-#include <QtGui/QDockWidget>
+#include <QDockWidget>
 
 class ConstantsWidget;
 

--- a/src/gui/constantswidget.cpp
+++ b/src/gui/constantswidget.cpp
@@ -22,15 +22,15 @@
 #include "core/constants.h"
 #include "core/settings.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QTimer>
-#include <QtGui/QComboBox>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QHeaderView>
-#include <QtGui/QLabel>
-#include <QtGui/QLineEdit>
-#include <QtGui/QTreeWidget>
-#include <QtGui/QVBoxLayout>
+#include <QEvent>
+#include <QTimer>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QTreeWidget>
+#include <QVBoxLayout>
 
 #include <algorithm>
 

--- a/src/gui/constantswidget.h
+++ b/src/gui/constantswidget.h
@@ -20,7 +20,7 @@
 #ifndef GUI_CONSTANTSWIDGET_H
 #define GUI_CONSTANTSWIDGET_H
 
-#include <QtGui/QWidget>
+#include <QWidget>
 
 class QComboBox;
 class QLabel;

--- a/src/gui/editor.cpp
+++ b/src/gui/editor.cpp
@@ -28,22 +28,22 @@
 #include "core/settings.h"
 #include "gui/syntaxhighlighter.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QMimeData>
-#include <QtCore/QTimeLine>
-#include <QtCore/QTimer>
-#include <QtGui/QApplication>
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QFont>
-#include <QtGui/QFrame>
-#include <QtGui/QHeaderView>
-#include <QtGui/QKeyEvent>
-#include <QtGui/QLineEdit>
-#include <QtGui/QPainter>
-#include <QtGui/QPlainTextEdit>
-#include <QtGui/QStyle>
-#include <QtGui/QTreeWidget>
-#include <QtGui/QWheelEvent>
+#include <QEvent>
+#include <QMimeData>
+#include <QTimeLine>
+#include <QTimer>
+#include <QApplication>
+#include <QDesktopWidget>
+#include <QFont>
+#include <QFrame>
+#include <QHeaderView>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QPainter>
+#include <QPlainTextEdit>
+#include <QStyle>
+#include <QTreeWidget>
+#include <QWheelEvent>
 
 #include <algorithm>
 

--- a/src/gui/editor.h
+++ b/src/gui/editor.h
@@ -20,7 +20,7 @@
 #ifndef GUI_EDITOR_H
 #define GUI_EDITOR_H
 
-#include <QtGui/QPlainTextEdit>
+#include <QPlainTextEdit>
 
 struct Constant;
 class ConstantCompletion;

--- a/src/gui/functionsdock.cpp
+++ b/src/gui/functionsdock.cpp
@@ -21,7 +21,7 @@
 
 #include "gui/functionswidget.h"
 
-#include <QtCore/QEvent>
+#include <QEvent>
 
 FunctionsDock::FunctionsDock(QWidget *parent)
     : QDockWidget(parent)

--- a/src/gui/functionsdock.h
+++ b/src/gui/functionsdock.h
@@ -20,7 +20,7 @@
 #ifndef GUI_FUNCTIONSDOCK_H
 #define GUI_FUNCTIONSDOCK_H
 
-#include <QtGui/QDockWidget>
+#include <QDockWidget>
 
 class FunctionsWidget;
 

--- a/src/gui/functionswidget.cpp
+++ b/src/gui/functionswidget.cpp
@@ -22,14 +22,14 @@
 #include "core/functions.h"
 #include "core/settings.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QString>
-#include <QtCore/QTimer>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QLineEdit>
-#include <QtGui/QTreeWidget>
-#include <QtGui/QVBoxLayout>
+#include <QEvent>
+#include <QString>
+#include <QTimer>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QTreeWidget>
+#include <QVBoxLayout>
 
 FunctionsWidget::FunctionsWidget(QWidget* parent)
     : QWidget(parent)

--- a/src/gui/functionswidget.h
+++ b/src/gui/functionswidget.h
@@ -20,8 +20,8 @@
 #ifndef GUI_FUNCTIONSWIDGET_H
 #define GUI_FUNCTIONSWIDGET_H
 
-#include <QtCore/QList>
-#include <QtGui/QWidget>
+#include <QList>
+#include <QWidget>
 
 class QEvent;
 class QLabel;

--- a/src/gui/historydock.cpp
+++ b/src/gui/historydock.cpp
@@ -21,8 +21,8 @@
 
 #include "gui/historywidget.h"
 
-#include <QtCore/QEvent>
-#include <QtGui/QIcon>
+#include <QEvent>
+#include <QIcon>
 
 HistoryDock::HistoryDock(QWidget *parent)
     : QDockWidget(parent),

--- a/src/gui/historydock.h
+++ b/src/gui/historydock.h
@@ -20,7 +20,7 @@
 #ifndef GUI_HISTORYDOCK_H
 #define GUI_HISTORYDOCK_H
 
-#include <QtGui/QDockWidget>
+#include <QDockWidget>
 
 class HistoryWidget;
 class QListWidgetItem;

--- a/src/gui/historywidget.cpp
+++ b/src/gui/historywidget.cpp
@@ -19,9 +19,9 @@
 
 #include "gui/historywidget.h"
 
-#include <QtCore/QEvent>
-#include <QtGui/QListWidget>
-#include <QtGui/QVBoxLayout>
+#include <QEvent>
+#include <QListWidget>
+#include <QVBoxLayout>
 
 
 HistoryWidget::HistoryWidget(QWidget *parent)

--- a/src/gui/historywidget.h
+++ b/src/gui/historywidget.h
@@ -20,7 +20,7 @@
 #ifndef GUI_HISTORYWIDGET_H
 #define GUI_HISTORYWIDGET_H
 
-#include <QtGui/QWidget>
+#include <QWidget>
 
 class QListWidget;
 class QListWidgetItem;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -40,33 +40,33 @@
 #include "gui/variablesdock.h"
 #include "math/floatconfig.h"
 
-#include <QtCore/QLatin1String>
-#include <QtCore/QLocale>
-#include <QtCore/QTextStream>
-#include <QtCore/QTimer>
-#include <QtCore/QTranslator>
-#include <QtCore/QUrl>
-#include <QtGui/QAction>
-#include <QtGui/QApplication>
-#include <QtGui/QClipboard>
-#include <QtGui/QCloseEvent>
-#include <QtGui/QDesktopServices>
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QFileDialog>
-#include <QtGui/QFont>
-#include <QtGui/QFontDialog>
-#include <QtGui/QInputDialog>
-#include <QtGui/QLabel>
-#include <QtGui/QMenu>
-#include <QtGui/QMenuBar>
-#include <QtGui/QMessageBox>
-#include <QtGui/QPushButton>
-#include <QtGui/QToolTip>
-#include <QtGui/QScrollBar>
-#include <QtGui/QStatusBar>
-#include <QtGui/QVBoxLayout>
+#include <QLatin1String>
+#include <QLocale>
+#include <QTextStream>
+#include <QTimer>
+#include <QTranslator>
+#include <QUrl>
+#include <QAction>
+#include <QApplication>
+#include <QClipboard>
+#include <QCloseEvent>
+#include <QDesktopServices>
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QFont>
+#include <QFontDialog>
+#include <QInputDialog>
+#include <QLabel>
+#include <QMenu>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QStatusBar>
+#include <QToolTip>
+#include <QVBoxLayout>
 #ifdef Q_WS_X11
-#include <QtGui/QX11Info>
+#include <QX11Info>
 
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
@@ -1322,7 +1322,7 @@ void MainWindow::showSessionLoadDialog()
             QMessageBox::critical(this, tr("Error"), errMsg.arg(fname));
             return;
         }
-        HNumber num(val.toAscii().data());
+        HNumber num(val.toLatin1().data());
         if (num != HMath::nan())
             m_evaluator->setVariable(var, num);
     }
@@ -1558,10 +1558,19 @@ void MainWindow::saveSession()
     file.close();
 }
 
+inline static QString documentsLocation()
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    return QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#else
+    return QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
+#endif
+}
+
 void MainWindow::exportHtml()
 {
     QString fname = QFileDialog::getSaveFileName(this, tr("Export session as HTML"),
-        QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation));
+        documentsLocation());
 
     if (fname.isEmpty())
         return;
@@ -1582,7 +1591,7 @@ void MainWindow::exportHtml()
 void MainWindow::exportPlainText()
 {
     QString fname = QFileDialog::getSaveFileName(this, tr("Export session as plain text"),
-        QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation));
+        documentsLocation());
 
     if (fname.isEmpty())
         return;
@@ -2013,7 +2022,7 @@ void MainWindow::restoreVariables()
         Evaluator::Variable::Type type = Evaluator::Variable::UserDefined;
         if (list.at(0) == QLatin1String("ans"))
             type = Evaluator::Variable::BuiltIn;
-        m_evaluator->setVariable(list.at(0), HNumber(list.at(1).toAscii().data()), type);
+        m_evaluator->setVariable(list.at(0), HNumber(list.at(1).toLatin1().data()), type);
     }
 
     if (m_docks.variables)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -21,8 +21,8 @@
 #ifndef GUI_MAINWINDOW_H
 #define GUI_MAINWINDOW_H
 
-#include <QtGui/QMainWindow>
-#include <QtGui/QSystemTrayIcon>
+#include <QMainWindow>
+#include <QSystemTrayIcon>
 
 class AutoHideLabel;
 class BookDock;

--- a/src/gui/manualwindow.h
+++ b/src/gui/manualwindow.h
@@ -21,7 +21,7 @@
 
 #include "core/manual.h"
 
-#include <QtGui/QTextBrowser>
+#include <QTextBrowser>
 
 class QCloseEvent;
 class QEvent;

--- a/src/gui/resultdisplay.cpp
+++ b/src/gui/resultdisplay.cpp
@@ -25,11 +25,11 @@
 #include "math/hmath.h"
 #include "math/floatconfig.h"
 
-#include <QtCore/QLatin1String>
-#include <QtGui/QApplication>
-#include <QtGui/QClipboard>
-#include <QtGui/QPainter>
-#include <QtGui/QScrollBar>
+#include <QLatin1String>
+#include <QApplication>
+#include <QClipboard>
+#include <QPainter>
+#include <QScrollBar>
 
 #define OVERLAY_GRADIENT_HEIGHT 50
 

--- a/src/gui/resultdisplay.h
+++ b/src/gui/resultdisplay.h
@@ -19,8 +19,8 @@
 #ifndef GUI_RESULTDISPLAY_H
 #define GUI_RESULTDISPLAY_H
 
-#include <QtCore/QBasicTimer>
-#include <QtGui/QPlainTextEdit>
+#include <QBasicTimer>
+#include <QPlainTextEdit>
 
 class HNumber;
 class FadeOverlay;

--- a/src/gui/syntaxhighlighter.cpp
+++ b/src/gui/syntaxhighlighter.cpp
@@ -24,10 +24,10 @@
 #include "core/functions.h"
 #include "core/settings.h"
 
-#include <QtCore/QLatin1String>
-#include <QtGui/QApplication>
-#include <QtGui/QPalette>
-#include <QtGui/QPlainTextEdit>
+#include <QLatin1String>
+#include <QApplication>
+#include <QPalette>
+#include <QPlainTextEdit>
 
 #define SH(x,r,g,b) (setColorForRole(SyntaxHighlighter::x, QColor(r,g,b)))
 

--- a/src/gui/tipwidget.cpp
+++ b/src/gui/tipwidget.cpp
@@ -19,12 +19,12 @@
 
 #include <gui/tipwidget.h>
 
-#include <QtCore/QTimer>
-#include <QtCore/QTimeLine>
-#include <QtGui/QLabel>
-#include <QtGui/QPushButton>
-#include <QtGui/QResizeEvent>
-#include <QtGui/QToolTip>
+#include <QTimer>
+#include <QTimeLine>
+#include <QLabel>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QToolTip>
 
 struct TipWidget::Private
 {

--- a/src/gui/tipwidget.h
+++ b/src/gui/tipwidget.h
@@ -20,7 +20,7 @@
 #ifndef TIPWIDGET_H
 #define TIPWIDGET_H
 
-#include <QtGui/QFrame>
+#include <QFrame>
 
 #include <memory>
 

--- a/src/gui/variablelistwidget.cpp
+++ b/src/gui/variablelistwidget.cpp
@@ -23,15 +23,15 @@
 #include "core/evaluator.h"
 #include "core/settings.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QTimer>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QKeyEvent>
-#include <QtGui/QLabel>
-#include <QtGui/QLineEdit>
-#include <QtGui/QMenu>
-#include <QtGui/QTreeWidget>
-#include <QtGui/QVBoxLayout>
+#include <QEvent>
+#include <QTimer>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
+#include <QTreeWidget>
+#include <QVBoxLayout>
 
 static QString formatValue(const HNumber& value);
 

--- a/src/gui/variablelistwidget.h
+++ b/src/gui/variablelistwidget.h
@@ -20,8 +20,8 @@
 #ifndef GUI_VARIABLELISTWIDGET_H
 #define GUI_VARIABLELISTWIDGET_H
 
-#include <QtCore/QList>
-#include <QtGui/QWidget>
+#include <QList>
+#include <QWidget>
 
 class QEvent;
 class QKeyEvent;

--- a/src/gui/variablesdock.cpp
+++ b/src/gui/variablesdock.cpp
@@ -21,13 +21,13 @@
 
 #include "gui/variablelistwidget.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QTimer>
-#include <QtGui/QIcon>
-#include <QtGui/QLabel>
-#include <QtGui/QLineEdit>
-#include <QtGui/QTreeWidget>
-#include <QtGui/QVBoxLayout>
+#include <QEvent>
+#include <QTimer>
+#include <QIcon>
+#include <QLabel>
+#include <QLineEdit>
+#include <QTreeWidget>
+#include <QVBoxLayout>
 
 VariablesDock::VariablesDock(QWidget*  parent)
     : QDockWidget(parent)

--- a/src/gui/variablesdock.h
+++ b/src/gui/variablesdock.h
@@ -20,7 +20,7 @@
 #ifndef GUI_VARIABLESDOCK_H
 #define GUI_VARIABLESDOCK_H
 
-#include <QtGui/QDockWidget>
+#include <QDockWidget>
 
 class QTreeWidgetItem;
 class VariableListWidget;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,8 +20,8 @@
 #include "gui/application.h"
 #include "gui/mainwindow.h"
 
-#include <QtCore/QCoreApplication>
-#include <QtGui/QApplication>
+#include <QCoreApplication>
+#include <QApplication>
 
 int main(int argc, char* argv[])
 {

--- a/src/speedcrunch.pro
+++ b/src/speedcrunch.pro
@@ -1,9 +1,8 @@
-QT_VERSION = $$[QT_VERSION]
-QT_VERSION = $$split(QT_VERSION, ".")
-QT_VER_MAJ = $$member(QT_VERSION, 0)
-QT_VER_MIN = $$member(QT_VERSION, 1)
+equals(QT_MAJOR_VERSION, 5) {
+    QT += widgets
+}
 
-lessThan(QT_VER_MAJ, 4) | lessThan(QT_VER_MIN, 8) {
+equals(QT_MAJOR_VERSION, 4) : lessThan(QT_MINOR_VERSION, 8) {
     error(Qt 4.8 or newer is required but version $$[QT_VERSION] was detected.)
 }
 


### PR DESCRIPTION
- Set "QT += widgets" for Qt5 in .pro file
- Removed directory names from Qt includes
- Replaced some toAscii() with toLatin1()
- Added an #ifdef for getting "DocumentsLocation"
- Made createQSettings() work with Qt5

Note that menu integration in Ubuntu will only work with Ubuntu's
patched Qt version. That's the case for Qt4 and Qt5.
