### PR TITLE
Fix build on Windows systems with Qt5.

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2250,8 +2250,8 @@ void MainWindow::raiseWindow()
     activate();
 
 #ifdef Q_OS_WIN
-    SetWindowPos(winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-    SetWindowPos(winId(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+    SetWindowPos((HWND)winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+    SetWindowPos((HWND)winId(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 #endif // Q_OS_WIN
 
 #ifdef Q_WS_X11


### PR DESCRIPTION
WId, the return type of winId(), doesn't alias to HWND anymore in
Qt5, so we add a cast for that.
