### PR TITLE
Fix Qt 5 Windows compilation (alternative pull request)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2281,34 +2281,6 @@ void MainWindow::copy()
     m_copyWidget->copy();
 }
 
-void MainWindow::raiseWindow()
-{
-    activate();
-
-#ifdef Q_OS_WIN
-    SetWindowPos(winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-    SetWindowPos(winId(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-#endif // Q_OS_WIN
-
-#ifdef Q_WS_X11
-    static Atom NET_ACTIVE_WINDOW = XInternAtom(QX11Info::display(), "_NET_ACTIVE_WINDOW", False);
-
-    XClientMessageEvent xev;
-    xev.type = ClientMessage;
-    xev.window = winId();
-    xev.message_type = NET_ACTIVE_WINDOW;
-    xev.format = 32;
-    xev.data.l[0] = 2;
-    xev.data.l[1] = CurrentTime;
-    xev.data.l[2] = 0;
-    xev.data.l[3] = 0;
-    xev.data.l[4] = 0;
-
-    XSendEvent(QX11Info::display(), QX11Info::appRootWindow(), False,
-        (SubstructureNotifyMask | SubstructureRedirectMask), (XEvent*)&xev);
-#endif // Q_WS_X11
-}
-
 void MainWindow::restoreVariables()
 {
     for (int k = 0; k < m_settings->variables.count(); ++k) {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -67,7 +67,6 @@ signals:
 
 public slots:
     void copy();
-    void raiseWindow();
 
 private slots:
     void activate();


### PR DESCRIPTION
This patch removes the unused `MainWindow::raiseWindow` method that causes compilation to fail on Windows when using Qt 5.