### PR TITLE
Highlight user functions with the same color as builtin functions (inste...

### DIFF
--- a/src/gui/syntaxhighlighter.cpp
+++ b/src/gui/syntaxhighlighter.cpp
@@ -117,9 +117,9 @@ void SyntaxHighlighter::highlightBlock(const QString& text)
 
         case Token::stxIdentifier:
             color = colorForRole(Variable);
-            for (int i = 0; i < functionNames.count(); ++i)
-                if (functionNames.at(i).toLower() == tokenText)
-                    color = colorForRole(Function);
+            if (Evaluator::instance()->hasUserFunction(token.text())
+                || functionNames.contains(tokenText, Qt::CaseInsensitive))
+                color = colorForRole(Function);
             break;
 
         default:


### PR DESCRIPTION
...ad of the color for user variables).

Fix issue 531.

Note that the user functions names are case sensitive (it's not the case for builtin functions). For instance, both user functions MyFunc() and myFunc() can exist at the same time. I'm not sure it's a good thing though.
