### PR TITLE
more reasonable docking behavior

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -64,7 +64,7 @@ void Settings::load()
 
     QString key = QString::fromLatin1(KEY) + QLatin1String("/General/");
 
-    appVersion = settings->value(key + QLatin1String("AppVersion"), APP_VERSION_UNKN).toString();
+    appVersion = settings->value(key + QLatin1String("AppVersion"), APP_VERSION_UNKN).toString().toUInt(0, 16);
 
     // Angle mode special case.
     QString angleUnitStr;
@@ -226,7 +226,7 @@ void Settings::save()
     int k, i;
     QString key = KEY + QLatin1String("/General/");
 
-    settings->setValue(key + QLatin1String("AppVersion"), APP_VERSION_FULL);
+    settings->setValue(key + QLatin1String("AppVersion"), QString().sprintf("0x%06X", APP_VERSION));
 
     settings->setValue(key + QLatin1String("HistorySave"), historySave);
     settings->setValue(key + QLatin1String("LeaveLastExpression"), leaveLastExpression);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -26,12 +26,12 @@
 #include <QtCore/QStringList>
 #include <QtCore/QList>
 
-// current application version (format to be comparable lexicographically) 
-#define APP_VERSION_FULL "00.12.00.00"
+// current application version (0xMMNNPP format same as QT_VERSION) 
+#define APP_VERSION 0x001200
 // milestones for compatibility checks
-#define APP_VERSION_00120000 "00.12.00.00"
-// unknown format (always lexicographically <APP_VERSION_FULL) 
-#define APP_VERSION_UNKN "00.00.00.00"
+#define APP_VERSION_001200 0x001200
+// unknown format (always <APP_VERSION) 
+#define APP_VERSION_UNKN 0x000000
 
 class Settings {
 public:
@@ -40,7 +40,7 @@ public:
     void load();
     void save();
 
-    QString appVersion; // "00.00.00.00" format
+    unsigned appVersion; // 0xMMNNPP format
 
     char radixCharacter() const; // 0: Automatic.
     void setRadixCharacter(char c = 0);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1010,7 +1010,7 @@ void MainWindow::applySettings()
         move(m_settings->windowPosition);
 
     // docking layout has changed in 0.12 - reset window state
-    if (m_settings->appVersion < APP_VERSION_00120000)
+    if (m_settings->appVersion < APP_VERSION_001200)
       m_settings->windowState.clear();
     
     restoreState(m_settings->windowState);


### PR DESCRIPTION
- left & right panels grab the whole window height
- top & bottom panels have the same width as input editor & result window
- it's more reasonable the lists take full height (more items visible) and especially expected behavior for dockable bitfield widget (and other widget i'm working on) 
- also enables nesting panels (more docks side by side on the same side) - more freedom for user and again will be good for bitfield and other similar widgets
- .ini or Layout\State setting must be deleted (otherwise new docking style will not be activated by Qt and strange things can happen)

![sc-docking](https://cloud.githubusercontent.com/assets/589865/5098462/d6a988fc-6f86-11e4-88b0-e90431b23d2c.png)
