### PR TITLE
Add IEEE-754 encoding/decoding functions.

### DIFF
--- a/src/core/functions.cpp
+++ b/src/core/functions.cpp
@@ -629,6 +629,74 @@ HNumber function_mod(Function* f, const Function::ArgumentList& args)
     return args.at(0) % args.at(1);
 }
 
+HNumber function_ieee754_decode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_EITHER_ARGUMENT_COUNT(3, 4);
+    if (args.count() == 3) {
+        return HMath::decodeIeee754(args.at(0), args.at(1), args.at(2));
+    } else {
+        return HMath::decodeIeee754(args.at(0), args.at(1), args.at(2), args.at(3));
+    }
+}
+
+HNumber function_ieee754_encode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_EITHER_ARGUMENT_COUNT(3, 4);
+    if (args.count() == 3) {
+        return HMath::encodeIeee754(args.at(0), args.at(1), args.at(2));
+    } else {
+        return HMath::encodeIeee754(args.at(0), args.at(1), args.at(2), args.at(3));
+    }
+}
+
+HNumber function_ieee754_half_decode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::decodeIeee754(args.at(0), 5, 10);
+}
+
+HNumber function_ieee754_half_encode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::encodeIeee754(args.at(0), 5, 10);
+}
+
+HNumber function_ieee754_single_decode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::decodeIeee754(args.at(0), 8, 23);
+}
+
+HNumber function_ieee754_single_encode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::encodeIeee754(args.at(0), 8, 23);
+}
+
+HNumber function_ieee754_double_decode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::decodeIeee754(args.at(0), 11, 52);
+}
+
+HNumber function_ieee754_double_encode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::encodeIeee754(args.at(0), 11, 52);
+}
+
+HNumber function_ieee754_quad_decode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::decodeIeee754(args.at(0), 15, 112);
+}
+
+HNumber function_ieee754_quad_encode(Function* f, const Function::ArgumentList& args)
+{
+    ENSURE_ARGUMENT_COUNT(1);
+    return HMath::encodeIeee754(args.at(0), 15, 112);
+}
+
 void FunctionRepo::createFunctions()
 {
     // Analysis.
@@ -715,6 +783,18 @@ void FunctionRepo::createFunctions()
     FUNCTION_INSERT(shr);
     FUNCTION_INSERT(idiv);
     FUNCTION_INSERT(mod);
+
+    // IEEE-754.
+    FUNCTION_INSERT(ieee754_decode);
+    FUNCTION_INSERT(ieee754_encode);
+    FUNCTION_INSERT(ieee754_half_decode);
+    FUNCTION_INSERT(ieee754_half_encode);
+    FUNCTION_INSERT(ieee754_single_decode);
+    FUNCTION_INSERT(ieee754_single_encode);
+    FUNCTION_INSERT(ieee754_double_decode);
+    FUNCTION_INSERT(ieee754_double_encode);
+    FUNCTION_INSERT(ieee754_quad_decode);
+    FUNCTION_INSERT(ieee754_quad_encode);
 }
 
 FunctionRepo* FunctionRepo::instance()
@@ -785,6 +865,14 @@ void FunctionRepo::setNonTranslatableFunctionUsages()
     FUNCTION_USAGE(gcd, "n<sub>1</sub>; n<sub>2</sub>; ...");
     FUNCTION_USAGE(geomean, "x<sub>1</sub>; x<sub>2</sub>; ...");
     FUNCTION_USAGE(hex, "n");
+    FUNCTION_USAGE(ieee754_half_decode, "x");
+    FUNCTION_USAGE(ieee754_half_encode, "x");
+    FUNCTION_USAGE(ieee754_single_decode, "x");
+    FUNCTION_USAGE(ieee754_single_encode, "x");
+    FUNCTION_USAGE(ieee754_double_decode, "x");
+    FUNCTION_USAGE(ieee754_double_encode, "x");
+    FUNCTION_USAGE(ieee754_quad_decode, "x");
+    FUNCTION_USAGE(ieee754_quad_encode, "x");
     FUNCTION_USAGE(int, "x");
     FUNCTION_USAGE(lb, "x");
     FUNCTION_USAGE(lg, "x");
@@ -826,6 +914,8 @@ void FunctionRepo::setTranslatableFunctionUsages()
     FUNCTION_USAGE_TR(hyperpmf, tr("count; total; hits; trials"));
     FUNCTION_USAGE_TR(hypervar, tr("total; hits; trials"));
     FUNCTION_USAGE_TR(idiv, tr("dividend; divisor"));
+    FUNCTION_USAGE_TR(ieee754_decode, tr("x; exponent_bits; significand_bits [; exponent_bias]"));
+    FUNCTION_USAGE_TR(ieee754_encode, tr("x; exponent_bits; significand_bits [; exponent_bias]"));
     FUNCTION_USAGE_TR(log, tr("base; x"));
     FUNCTION_USAGE_TR(mask, tr("n; bits"));
     FUNCTION_USAGE_TR(mod, tr("value; modulo"));
@@ -878,6 +968,16 @@ void FunctionRepo::setFunctionNames()
     FUNCTION_NAME(hypervar, tr("Hypergeometric Distribution Variance"));
     FUNCTION_NAME(idiv, tr("Integer Quotient"));
     FUNCTION_NAME(int, tr("Integer Part"));
+    FUNCTION_NAME(ieee754_decode, tr("Decode IEEE-754 Binary Value"));
+    FUNCTION_NAME(ieee754_encode, tr("Encode IEEE-754 Binary Value"));
+    FUNCTION_NAME(ieee754_half_decode, tr("Decode 16-bit Half-Precision Value"));
+    FUNCTION_NAME(ieee754_half_encode, tr("Encode 16-bit Half-Precision Value"));
+    FUNCTION_NAME(ieee754_single_decode, tr("Decode 32-bit Single-Precision Value"));
+    FUNCTION_NAME(ieee754_single_encode, tr("Encode 32-bit Single-Precision Value"));
+    FUNCTION_NAME(ieee754_double_decode, tr("Decode 64-bit Double-Precision Value"));
+    FUNCTION_NAME(ieee754_double_encode, tr("Encode 64-bit Double-Precision Value"));
+    FUNCTION_NAME(ieee754_quad_decode, tr("Decode 128-bit Quad-Precision Value"));
+    FUNCTION_NAME(ieee754_quad_encode, tr("Encode 128-bit Quad-Precision Value"));
     FUNCTION_NAME(lb, tr("Binary Logarithm"));
     FUNCTION_NAME(lg, tr("Common Logarithm"));
     FUNCTION_NAME(ln, tr("Natural Logarithm"));

--- a/src/math/hmath.cpp
+++ b/src/math/hmath.cpp
@@ -1931,7 +1931,9 @@ HNumber HMath::encodeIeee754( const HNumber & val, const HNumber & exp_bits,
     }
   }
 
-  return sign_bit << (exp_bits + significand_bits) | exponent << (significand_bits) | significand;
+  HNumber result = sign_bit << (exp_bits + significand_bits) | exponent << (significand_bits) | significand;
+  result.setFormat('h');
+  return result;
 }
 
 std::ostream& operator<<( std::ostream& s, const HNumber& n )

--- a/src/math/hmath.cpp
+++ b/src/math/hmath.cpp
@@ -1823,6 +1823,105 @@ HNumber HMath::ashr( const HNumber & val, const HNumber & bits )
   return val << -bits;
 }
 
+/**
+ * Decode a IEEE-754 bit pattern with the given parameters
+ */
+HNumber HMath::decodeIeee754( const HNumber & val, const HNumber & exp_bits, const HNumber & significand_bits )
+{
+  if ( val.isNan()
+       || exp_bits <= 0 || exp_bits >= LOGICRANGE || ! exp_bits.isInteger()
+       || significand_bits <= 0 || significand_bits >= LOGICRANGE || ! significand_bits.isInteger())
+    return HMath::nan();
+
+  HNumber sign(HMath::mask(val >> (exp_bits + significand_bits), 1).isZero() ? 1 : -1);
+  HNumber exp = HMath::mask(val >> significand_bits, exp_bits);
+  HNumber exp_value = exp - HMath::raise(2, exp_bits - 1) + 1;
+  // <=> '0.' b_x b_x-1 b_x-2 ... b_0
+  HNumber significand = HMath::mask(val, significand_bits) * HMath::raise(2, -significand_bits);
+
+  if (exp.isZero()) {
+    // Exponent 0, subnormal value or zero.
+    return sign * significand * HMath::raise(2, exp_value + 1);
+  } else if (exp - HMath::raise(2, exp_bits) == -1) {
+    // Exponent all 1...
+    if (significand.isZero()) {
+      // ...and signficand 0, infinity.
+      // TODO: Represent infinity as something other than NaN?
+      return HNumber();
+    } else {
+      // ...and significand not 0, NaN.
+      return HMath::nan();
+    }
+  } else {
+    // Normalised value.
+    return sign * (significand + 1) * HMath::raise(2, exp_value);
+  }
+}
+
+/**
+ * Encode a value in a IEEE-754 binary representation
+ */
+HNumber HMath::encodeIeee754( const HNumber & val, const HNumber & exp_bits, const HNumber & significand_bits )
+{
+  if ( exp_bits <= 0 || exp_bits >= LOGICRANGE || ! exp_bits.isInteger()
+       || significand_bits <= 0 || significand_bits >= LOGICRANGE || ! significand_bits.isInteger())
+    return HMath::nan();
+
+  HNumber sign_bit;
+  HNumber significand;
+  HNumber exponent;
+
+  HNumber min_exp(2 - HMath::raise(2, exp_bits - 1));
+  HNumber max_exp(HMath::raise(2, exp_bits - 1) - 1);
+
+  if (val.isNan()) {
+    // Encode a NaN.
+    sign_bit = 0;
+    significand = HMath::raise(2, significand_bits) - 1;
+    exponent = HMath::raise(2, exp_bits) - 1;
+  } else if (val.isZero()) {
+    // Encode a basic 0.
+    sign_bit = 0;
+    significand = 0;
+    exponent = 0;
+  } else {
+    // Regular input value.
+    sign_bit = val.isNegative() ? 1 : 0;
+
+    // Determine exponent.
+    significand = HMath::abs(val);
+    exponent = 0;
+    while (exponent > min_exp && exponent < max_exp) {
+      HNumber intpart = HMath::integer(significand);
+      if (intpart == 1) {
+        break;
+      } else if (intpart > 1) {
+        exponent += 1;
+      } else {
+        exponent -= 1;
+      }
+      significand = HMath::abs(val) * HMath::raise(2, -exponent);
+    }
+
+    HNumber rounded = HMath::round(significand * HMath::raise(2, significand_bits));
+    HNumber intpart = HMath::integer(rounded * HMath::raise(2, -significand_bits));
+    significand = HMath::mask(rounded, significand_bits);
+    if (intpart.isZero()) {
+      // Subnormal value.
+      exponent = 0;
+    } else if (intpart > 1) {
+      // Infinity.
+      exponent = HMath::raise(2, exp_bits) - 1;
+      significand = 0;
+    } else {
+      // Normalised value.
+      exponent = exponent + max_exp;
+    }
+  }
+
+  return sign_bit << (exp_bits + significand_bits) | exponent << (significand_bits) | significand;
+}
+
 std::ostream& operator<<( std::ostream& s, const HNumber& n )
 {
   char* str = HMath::format( n, 'f' );

--- a/src/math/hmath.cpp
+++ b/src/math/hmath.cpp
@@ -1910,10 +1910,25 @@ HNumber HMath::encodeIeee754( const HNumber & val, const HNumber & exp_bits,
     sign_bit = val.isNegative() ? 1 : 0;
 
     // Determine exponent.
-    for (exponent = min_exp;
-         (significand = HMath::abs(val) * HMath::raise(2, -exponent)) >= 2
-         && exponent < max_exp;
-         exponent += 1);
+    HNumber search_min = min_exp;
+    HNumber search_max = max_exp;
+    exponent = HMath::ceil((search_max - search_min) / 2) + search_min;
+    significand = HMath::abs(val) * HMath::raise(2, -exponent);
+
+    do {
+      if (significand >= 1 && significand < 2) {
+        // Integer part is 1, stop here.
+        break;
+      } else if (significand >= 2) {
+        // Increase exponent.
+        search_min = exponent + 1;
+      } else if (significand < 1) {
+        // Decrease exponent.
+        search_max = exponent - 1;
+      }
+      exponent = HMath::ceil((search_max - search_min) / 2) + search_min;
+      significand = HMath::abs(val) * HMath::raise(2, -exponent);
+    } while (exponent != min_exp && exponent != max_exp);
 
     HNumber rounded = HMath::round(significand * HMath::raise(2, significand_bits));
     HNumber intpart = HMath::integer(rounded * HMath::raise(2, -significand_bits));

--- a/src/math/hmath.h
+++ b/src/math/hmath.h
@@ -169,6 +169,9 @@ class HMath
     static HNumber mask( const HNumber & val, const HNumber & bits );
     static HNumber sgnext( const HNumber & val, const HNumber & bits );
     static HNumber ashr( const HNumber & val, const HNumber & bits );
+    // IEEE-754 CONVERSION
+    static HNumber decodeIeee754( const HNumber & val, const HNumber & exp_bits, const HNumber & significand_bits );
+    static HNumber encodeIeee754( const HNumber & val, const HNumber & exp_bits, const HNumber & significand_bits );
 };
 
 std::ostream & operator<<( std::ostream &, const HNumber & );

--- a/src/math/hmath.h
+++ b/src/math/hmath.h
@@ -170,8 +170,14 @@ class HMath
     static HNumber sgnext( const HNumber & val, const HNumber & bits );
     static HNumber ashr( const HNumber & val, const HNumber & bits );
     // IEEE-754 CONVERSION
-    static HNumber decodeIeee754( const HNumber & val, const HNumber & exp_bits, const HNumber & significand_bits );
-    static HNumber encodeIeee754( const HNumber & val, const HNumber & exp_bits, const HNumber & significand_bits );
+    static HNumber decodeIeee754( const HNumber & val, const HNumber & exp_bits,
+                                  const HNumber & significand_bits );
+    static HNumber decodeIeee754( const HNumber & val, const HNumber & exp_bits,
+                                  const HNumber & significand_bits, const HNumber & exp_bias );
+    static HNumber encodeIeee754( const HNumber & val, const HNumber & exp_bits,
+                                  const HNumber & significand_bits );
+    static HNumber encodeIeee754( const HNumber & val, const HNumber & exp_bits,
+                                  const HNumber & significand_bits, const HNumber & exp_bias );
 };
 
 std::ostream & operator<<( std::ostream &, const HNumber & );

--- a/src/tests/testhmath.cpp
+++ b/src/tests/testhmath.cpp
@@ -900,10 +900,17 @@ void test_functions()
     CHECK(HMath::decodeIeee754("0x41200000", "8", "23"), "10");
     CHECK(HMath::decodeIeee754("0xc1200000", "8", "23"), "-10");
     CHECK(HMath::decodeIeee754("0x3fc00000", "8", "23"), "1.5");
+    CHECK_PRECISE(HMath::decodeIeee754("0x3dcccccd", "8", "23"), "0.10000000149011611938476562500000000000000000000000");
     CHECK(HMath::decodeIeee754("0x7f7fffff", "8", "23"), "340282346638528859811704183484516925440");
-    CHECK_PRECISE(HMath::decodeIeee754("0x418100b9", "8", "23"), "16.12535285949707031250000000000000000000000000000000");
+    CHECK(HMath::decodeIeee754("0x418100b9", "8", "23"), "16.1253528594970703125");
     CHECK(HMath::decodeIeee754("0x4024000000000000", "11", "52"), "10");
-
+    CHECK(HMath::decodeIeee754("0x01", "4", "3", "-2"), "1");
+    CHECK(HMath::decodeIeee754("0x07", "4", "3", "-2"), "7");
+    CHECK(HMath::decodeIeee754("0x08", "4", "3", "-2"), "8");
+    CHECK(HMath::decodeIeee754("0xf1", "4", "3", "-2"), "-73728");
+    CHECK(HMath::decodeIeee754("0x77", "4", "3", "-2"), "122880");
+    CHECK(HMath::decodeIeee754("0x5", "2", "1"), "3");
+    CHECK_PRECISE(HMath::decodeIeee754("0x3ffd5555555555555555555555555555", "15", "112"), "0.33333333333333333333333333333333331728391713010637");
     CHECK(HMath::encodeIeee754("NaN", "NaN", "NaN"), "NaN");
     CHECK(HMath::encodeIeee754("1", "NaN", "NaN"), "NaN");
     CHECK(HMath::encodeIeee754("1", "-1", "1"), "NaN");
@@ -920,6 +927,12 @@ void test_functions()
     CHECK_FORMAT('h', 0, HMath::encodeIeee754("-0.1", "8", "23"), "0xBDCCCCCD");
     CHECK_FORMAT('h', 0, HMath::encodeIeee754("-0.1", "11", "52"), "0xBFB999999999999A");
     CHECK_FORMAT('h', 0, HMath::encodeIeee754("16.1253528594970703125", "8", "23"), "0x418100B9");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("1", "4", "3", "-2"), "0x1");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("7", "4", "3", "-2"), "0x7");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("8", "4", "3", "-2"), "0x8");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("-73728", "4", "3", "-2"), "0xF1");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("122880", "4", "3", "-2"), "0x77");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("3", "2", "1"), "0x5");
 }
 
 int main(int argc, char* argv[])

--- a/src/tests/testhmath.cpp
+++ b/src/tests/testhmath.cpp
@@ -885,6 +885,41 @@ void test_functions()
     CHECK_PRECISE(HMath::cosh("0.8"), "1.33743494630484459800481995820531977649392453816033");
     CHECK_PRECISE(HMath::cosh("0.9"), "1.43308638544877438784179040162404834162773784130523");
     CHECK_PRECISE(HMath::cosh("1.0"), "1.54308063481524377847790562075706168260152911236586");
+
+    CHECK(HMath::decodeIeee754("NaN", "NaN", "NaN"), "NaN");
+    CHECK(HMath::decodeIeee754("1", "-1", "1"), "NaN");
+    CHECK(HMath::decodeIeee754("1", "1", "0"), "NaN");
+    CHECK(HMath::decodeIeee754("1", "1.5", "1"), "NaN");
+    CHECK(HMath::decodeIeee754("0", "5", "10"), "0");
+    CHECK(HMath::decodeIeee754("0x7ff00000", "8", "23"), "NaN");
+    CHECK(HMath::decodeIeee754("0xffc0feed", "8", "23"), "NaN");
+    CHECK(HMath::decodeIeee754("0x7fffffff", "8", "23"), "NaN");
+    CHECK(HMath::decodeIeee754("0x8000", "5", "10"), "0");
+    CHECK_PRECISE(HMath::decodeIeee754("0x00800000", "8", "23"), "0.00000000000000000000000000000000000001175494350822");
+    CHECK_PRECISE(HMath::decodeIeee754("0x006f6eed", "8", "23"), "0.00000000000000000000000000000000000001023353274603");
+    CHECK(HMath::decodeIeee754("0x41200000", "8", "23"), "10");
+    CHECK(HMath::decodeIeee754("0xc1200000", "8", "23"), "-10");
+    CHECK(HMath::decodeIeee754("0x3fc00000", "8", "23"), "1.5");
+    CHECK(HMath::decodeIeee754("0x7f7fffff", "8", "23"), "340282346638528859811704183484516925440");
+    CHECK_PRECISE(HMath::decodeIeee754("0x418100b9", "8", "23"), "16.12535285949707031250000000000000000000000000000000");
+    CHECK(HMath::decodeIeee754("0x4024000000000000", "11", "52"), "10");
+
+    CHECK(HMath::encodeIeee754("NaN", "NaN", "NaN"), "NaN");
+    CHECK(HMath::encodeIeee754("1", "NaN", "NaN"), "NaN");
+    CHECK(HMath::encodeIeee754("1", "-1", "1"), "NaN");
+    CHECK(HMath::encodeIeee754("1", "1", "0"), "NaN");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("NaN", "5", "10"), "0x7FFF");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("NaN", "11", "52"), "0x7FFFFFFFFFFFFFFF");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("0", "5", "10"), "0");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("1.17549435E-38", "8", "23"), "0x800000");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("10", "8", "23"), "0x41200000");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("-10", "8", "23"), "0xC1200000");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("1.5", "8", "23"), "0x3FC00000");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("340282346638528859811704183484516925440","8", "23"), "0x7F7FFFFF");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("9999999999999999999999999999999999", "5", "10"), "0x7C00");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("-0.1", "8", "23"), "0xBDCCCCCD");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("-0.1", "11", "52"), "0xBFB999999999999A");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("16.1253528594970703125", "8", "23"), "0x418100B9");
 }
 
 int main(int argc, char* argv[])

--- a/src/tests/testhmath.cpp
+++ b/src/tests/testhmath.cpp
@@ -911,6 +911,7 @@ void test_functions()
     CHECK(HMath::decodeIeee754("0x77", "4", "3", "-2"), "122880");
     CHECK(HMath::decodeIeee754("0x5", "2", "1"), "3");
     CHECK_PRECISE(HMath::decodeIeee754("0x3ffd5555555555555555555555555555", "15", "112"), "0.33333333333333333333333333333333331728391713010637");
+
     CHECK(HMath::encodeIeee754("NaN", "NaN", "NaN"), "NaN");
     CHECK(HMath::encodeIeee754("1", "NaN", "NaN"), "NaN");
     CHECK(HMath::encodeIeee754("1", "-1", "1"), "NaN");
@@ -933,6 +934,7 @@ void test_functions()
     CHECK_FORMAT('h', 0, HMath::encodeIeee754("-73728", "4", "3", "-2"), "0xF1");
     CHECK_FORMAT('h', 0, HMath::encodeIeee754("122880", "4", "3", "-2"), "0x77");
     CHECK_FORMAT('h', 0, HMath::encodeIeee754("3", "2", "1"), "0x5");
+    CHECK_FORMAT('h', 0, HMath::encodeIeee754("1.5", "2", "1"), "0x3");
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Adds functions to encode and decode IEEE-754 binary floats (for various standard formats as well generic parametrisable ones). I went with long, expressive function names here rather than trying to make them more easily typeable, but I'm open to other suggestions.

Should also fix https://code.google.com/p/speedcrunch/issues/detail?id=505