### PR TITLE
Fix building with Qt 5.5.

### DIFF
--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -21,6 +21,7 @@
 #ifndef CORE_CONSTANTS_H
 #define CORE_CONSTANTS_H
 
+#include <QObject>
 #include <QStringList>
 
 #include <memory>

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -24,6 +24,7 @@
 #include "math/hmath.h"
 
 #include <QHash>
+#include <QObject>
 #include <QStringList>
 #include <QVector>
 


### PR DESCRIPTION
A few files were relying on other Qt headers implicitly pulling in QObject.